### PR TITLE
docs: correct links to code-specifications

### DIFF
--- a/documentation/basics/typography/typography-de.md
+++ b/documentation/basics/typography/typography-de.md
@@ -12,7 +12,7 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/GLdV0O#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.2 Überschrift H2
 ![Darstellung des Schriftstils Überschrift H2](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_h2.png 'class: image')
@@ -22,7 +22,7 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/OzREJm#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.3 Überschrift H3
 ![Darstellung des Schriftstils Überschrift H3](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_h3.png 'class: image')
@@ -31,7 +31,7 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/mjKVgP#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.4 Überschrift H4
 ![Darstellung des Schriftstils Überschrift H4](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_h4.png 'class: image')
@@ -40,14 +40,14 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/DKwRD4#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.5 Lead
 ![Darstellung des Schriftstils Lead-Text](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_lead.png 'class: image')
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/apaOED#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 
 ### 2.6 Fliesstext (Copy)
@@ -55,7 +55,7 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ApRlGR#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.7 Link
 ![Darstellung des Schriftstils Link](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_link.png 'class: image')
@@ -64,14 +64,14 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/0Z7bOG#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.8 Subtext
 ![Darstellung des Schriftstils Subtext](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_subtext.png 'class: image')
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/lgGpYz#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.9 Tabellenheader
 ![Darstellung des Schriftstils Tabellenheader](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_table_header.png 'class: image')
@@ -79,7 +79,7 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/kPQ1Yr#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.10 Tabellendaten
 ![Darstellung des Schriftstils Tabellendaten](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_table_data.png 'class: image')
@@ -87,7 +87,7 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ozDKWL#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.11 Liste geordnet
 ![Darstellung des Schriftstils Liste geordnet](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_list_ordered.png 'class: image')
@@ -98,7 +98,7 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/Rvo8eW#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.12 Liste ungeordnet
 ![Darstellung des Schriftstils Liste ungeordnet](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_list_unordered.png 'class: image')
@@ -109,18 +109,18 @@ Die hier definierten Schriftstile bilden die Basis von Webseiten und deren Kompo
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/1JPWm5#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.13 Fieldset einfach
 ![Darstellung des Schriftstils Fieldset einfach](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_fieldset_default.png 'class: image')
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/pZKwWo#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.14 Fieldset verschachtelt
 ![Darstellung des Schriftstils Fieldset verschachtelt](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_fieldset_nested.png 'class: image')
 
 #### Spezifikation
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/VOobD8#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)

--- a/documentation/basics/typography/typography-en.md
+++ b/documentation/basics/typography/typography-en.md
@@ -12,7 +12,7 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/GLdV0O#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.2 Heading H2
 ![Image of the heading H2 text font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_h2.png 'class: image')
@@ -22,7 +22,7 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/OzREJm#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.3 Heading H3
 ![Image of the heading H3 text font style3](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_h3.png 'class: image')
@@ -31,7 +31,7 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/mjKVgP#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.4 Heading H4
 ![Image of the heading H4 text font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_h4.png 'class: image')
@@ -40,14 +40,14 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/DKwRD4#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.5 Lead
 ![Image of the lead text font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_lead.png 'class: image')
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/apaOED#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 
 ### 2.6 Body copy
@@ -55,7 +55,7 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ApRlGR#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.7 Link
 ![Image of the link font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_link.png 'class: image')
@@ -64,14 +64,14 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/0Z7bOG#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.8 Subtext
 ![Image of the subtext font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_subtext.png 'class: image')
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/lgGpYz#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.9 Table header
 ![Image of the table header font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_table_header.png 'class: image')
@@ -79,7 +79,7 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/kPQ1Yr#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.10 Table data
 ![Image of the table data font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_table_data.png 'class: image')
@@ -87,7 +87,7 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ozDKWL#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.11 List structure
 ![Image of the list structure font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_list_ordered.png 'class: image')
@@ -98,7 +98,7 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/Rvo8eW#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.12 Unstructured list
 ![Image of the unstructured list font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_list_unordered.png 'class: image')
@@ -109,18 +109,18 @@ The font styles defined here form the basis of web applications and their compon
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/1JPWm5#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.13 Fieldset simple
 ![Image of the fieldset simple font style](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_fieldset_default.png 'class: image')
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/pZKwWo#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ### 2.14 Fieldset complex
 ![Image of the fieldset font style complex](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/basics/typography/images/typo_fieldset_nested.png 'class: image')
 
 #### Specification
 * [Design](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/VOobD8#Inspector)
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)

--- a/documentation/components/accordion/accordion-de.md
+++ b/documentation/components/accordion/accordion-de.md
@@ -29,4 +29,4 @@ Die Komponente hat folgende Zustände:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/KPRqjr#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/accordion)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/accordion)

--- a/documentation/components/accordion/accordion-en.md
+++ b/documentation/components/accordion/accordion-en.md
@@ -29,4 +29,4 @@ The component has the following statuses:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/KPRqjr#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/accordion)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/accordion)

--- a/documentation/components/autocompletion/autocompletion-de.md
+++ b/documentation/components/autocompletion/autocompletion-de.md
@@ -27,7 +27,7 @@ Die Komponente hat folgende Zustände:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/qJVqWk#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/autocomplete)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/autocomplete)
 
 ### 4.2 Mit Trefferanzeige
 Optional zur Standard-Ausprägung kann diese Variante eingesetzt werden, wenn eine Autocompletion-Liste immer mehr als die maximal angezeigten 10 Treffer beinhaltet.
@@ -38,7 +38,7 @@ Optional zur Standard-Ausprägung kann diese Variante eingesetzt werden, wenn ei
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/7mavk8#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/autocomplete)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/autocomplete)
 
 ### 4.3 Mit statischen Einträgen
 ![Darstellung der Komponente Autocompletion mit statischen Einträgen](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/autocompletion/images/autocompletion_static.png 'class: image')
@@ -48,4 +48,4 @@ Optional zur Standard-Ausprägung kann diese Variante eingesetzt werden, wenn ei
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/9aWejn#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/autocomplete)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/autocomplete)

--- a/documentation/components/autocompletion/autocompletion-en.md
+++ b/documentation/components/autocompletion/autocompletion-en.md
@@ -27,7 +27,7 @@ The component has the following statuses:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/qJVqWk#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/autocomplete)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/autocomplete)
 
 ### 4.2 With display of hits
 As an option to the standard variant, this variant can be used when an auto-completion list always contains more than the maximum ten hits shown.
@@ -38,7 +38,7 @@ As an option to the standard variant, this variant can be used when an auto-comp
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/7mavk8#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/autocomplete)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/autocomplete)
 
 ### 4.3 Mit statischen Einträgen
 ![Image of the autocompletion component with static entries](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/autocompletion/images/autocompletion_static.png 'class: image')
@@ -48,4 +48,4 @@ As an option to the standard variant, this variant can be used when an auto-comp
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/9aWejn#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/autocomplete)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/autocomplete)

--- a/documentation/components/breadcrumb/breadcrumb-de.md
+++ b/documentation/components/breadcrumb/breadcrumb-de.md
@@ -28,7 +28,7 @@ Beim Viewport «Mobile» gibt es folgende Zustände:
 * [Hover/Overflow](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/gLZlYz#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/breadcrumb)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/breadcrumb)
 
 ### 4.2 Mit Schwesterseiten
 Diese Ausprägung hat zusätzlich folgende Zustände:
@@ -46,4 +46,4 @@ Diese Ausprägung hat zusätzlich folgende Zustände:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/MjM7zw#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/breadcrumb)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/breadcrumb)

--- a/documentation/components/breadcrumb/breadcrumb-en.md
+++ b/documentation/components/breadcrumb/breadcrumb-en.md
@@ -28,7 +28,7 @@ The following statuses exist for the ‘mobile’ viewport:
 * [Hover/Overflow](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/gLZlYz#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/breadcrumb)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/breadcrumb)
 
 ### 4.2 With sister pages
 This variant also has the following statuses:
@@ -46,4 +46,4 @@ This variant also has the following statuses:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/MjM7zw#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/breadcrumb)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/breadcrumb)

--- a/documentation/components/button/button-de.md
+++ b/documentation/components/button/button-de.md
@@ -34,7 +34,7 @@ Die Komponente hat folgende Zustände:
 * [Disabled](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/34xdar#Inspector) 
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/button)
 
 ### 4.2 Secondary Button
 ![Darstellung der Komponente Secondary Button](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/button/images/button_secondary.png 'class: image')
@@ -46,7 +46,7 @@ Die Komponente hat folgende Zustände:
 * [Disabled](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/xDQ8xJ#Inspector) 
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/button)
 
 ### 4.3 Ghost Button
 ![Darstellung der Komponente Ghost Button](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/button/images/button_ghost.png 'class: image')
@@ -57,7 +57,7 @@ Die Komponente hat folgende Zustände:
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/dKja5L#Inspector) 
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/button)
 
 ### 4.4 Frameless Button
 ![Darstellung der Komponente Frameless Button](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/button/images/button_frameless.png 'class: image')
@@ -68,4 +68,4 @@ Die Komponente hat folgende Zustände:
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/J9Jwok#Inspector) 
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/button)

--- a/documentation/components/button/button-en.md
+++ b/documentation/components/button/button-en.md
@@ -34,7 +34,7 @@ The component has the following statuses:
 * [Disabled](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/34xdar#Inspector) 
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/button)
 
 ### 4.2 Secondary button
 ![Image of the secondary button component](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/button/images/button_secondary.png 'class: image')
@@ -46,7 +46,7 @@ The component has the following statuses:
 * [Disabled](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/xDQ8xJ#Inspector) 
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/button)
 
 ### 4.3 Ghost button
 ![Image of the ghost button component](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/button/images/button_ghost.png 'class: image')
@@ -57,7 +57,7 @@ The component has the following statuses:
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/dKja5L#Inspector) 
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/button)
 
 ### 4.4 Frameless button
 ![Image of the frameless button component](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/button/images/button_frameless.png 'class: image')
@@ -68,4 +68,4 @@ The component has the following statuses:
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/J9Jwok#Inspector) 
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/button)

--- a/documentation/components/captcha/captcha-de.md
+++ b/documentation/components/captcha/captcha-de.md
@@ -21,4 +21,4 @@ Die Komponente hat folgende Zustände:
 * [Unchecked](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/4e5zAD#Inspector) 
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/captcha)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/captcha)

--- a/documentation/components/captcha/captcha-en.md
+++ b/documentation/components/captcha/captcha-en.md
@@ -21,4 +21,4 @@ The component has the following statuses:
 * [Unchecked](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/4e5zAD#Inspector) 
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/captcha)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/captcha)

--- a/documentation/components/checkbox/checkbox-de.md
+++ b/documentation/components/checkbox/checkbox-de.md
@@ -37,7 +37,7 @@ Die Komponente hat folgende Zustände:
 * [Disabled unchecked](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/j9rRJb#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/checkbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox)
 
 ### 4.2 Vertikale Checkbox-Gruppe 
 ![Darstellung der Komponente Checkbox als vertikale Gruppe](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/checkbox/images/checkbox_vertical.png 'class: image')
@@ -46,7 +46,7 @@ Die Komponente hat folgende Zustände:
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/dKja7j#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/checkbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox)
 
 ### 4.3 Horizontale Checkbox-Gruppe
 ![Darstellung der Komponente Checkbox als horizontale Gruppe](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/checkbox/images/checkbox_horizontal.png 'class: image')
@@ -55,4 +55,4 @@ Die Komponente hat folgende Zustände:
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/zAKM2l#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/checkbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox)

--- a/documentation/components/checkbox/checkbox-en.md
+++ b/documentation/components/checkbox/checkbox-en.md
@@ -37,7 +37,7 @@ The component has the following statuses:
 * [Disabled unchecked](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/j9rRJb#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/checkbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox)
 
 ### 4.2 Vertical checkbox group 
 ![Image of the checkbox as a vertical group component](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/checkbox/images/checkbox_vertical.png 'class: image')
@@ -46,7 +46,7 @@ The component has the following statuses:
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/dKja7j#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/checkbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox)
 
 ### 4.3 Horizontal checkbox group
 ![Image of the checkbox as a horizontal group component](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/checkbox/images/checkbox_horizontal.png 'class: image')
@@ -55,4 +55,4 @@ The component has the following statuses:
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/zAKM2l#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/checkbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox)

--- a/documentation/components/checkboxpanel/checkboxpanel-de.md
+++ b/documentation/components/checkboxpanel/checkboxpanel-de.md
@@ -31,7 +31,7 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ewdAWz#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/checkbox-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox-panel)
 
 ### 4.2 Mit Infotext
 ![Darstellung der Komponente Checkboxpanel mit zusätzlichem Hinweistext](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/checkboxpanel/images/checkboxpanel_infotext.png 'class: image')
@@ -44,7 +44,7 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/apaO7v#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/checkbox-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox-panel)
 
 ### 4.3 Mit Piktogramm / Logo
 ![Darstellung der Komponente Checkboxpanel mit zusätzlichem Piktogramm oder Logo](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/checkboxpanel/images/checkboxpanel_picto.png 'class: image')
@@ -57,4 +57,4 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ozDKOx#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/checkbox-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox-panel)

--- a/documentation/components/checkboxpanel/checkboxpanel-en.md
+++ b/documentation/components/checkboxpanel/checkboxpanel-en.md
@@ -31,7 +31,7 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ewdAWz#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/checkbox-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox-panel)
 
 ### 4.2 With info text
 ![Image of the checkbox panel component with additional information text](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/checkboxpanel/images/checkboxpanel_infotext.png 'class: image')
@@ -44,7 +44,7 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/apaO7v#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/checkbox-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox-panel)
 
 ### 4.3 With pictogram/logo
 ![Image of the checkbox panel image with additional pictogram or logo](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/checkboxpanel/images/checkboxpanel_picto.png 'class: image')
@@ -57,4 +57,4 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ozDKOx#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/checkbox-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/checkbox-panel)

--- a/documentation/components/datepicker/datepicker-de.md
+++ b/documentation/components/datepicker/datepicker-de.md
@@ -38,7 +38,7 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/VOob9A#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/datepicker)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/datepicker)
 
 ### 4.2 Mit Blätterfunktion
 ![Darstellung der Komponente Datumswahl mit Blätterfunktion](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/datepicker/images/datepicker_pageable.png 'class: image')
@@ -56,7 +56,7 @@ Die Komponente hat folgende Zustände:
 * [Disabled](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/wmQgoq#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/datepicker)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/datepicker)
 
 ### 4.3 Datumsbereich
 * Um einen Datumsbereich zu wählen, werden zwei Datepicker kombiniert.
@@ -76,7 +76,7 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/yaQ2xa#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/datepicker)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/datepicker)
 
 ### 4.5 Kalender-Layer
 ![Darstellung der Komponente Datumswahl mit geöffnetem Datepicker](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/datepicker/images/datepicker_picker.png 'class: image')
@@ -97,4 +97,4 @@ defniert:
 * [Datumsbereich über Monatsgrenze](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/MjM7A7#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/datepicker)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/datepicker)

--- a/documentation/components/datepicker/datepicker-en.md
+++ b/documentation/components/datepicker/datepicker-en.md
@@ -38,7 +38,7 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/VOob9A#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/datepicker)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/datepicker)
 
 ### 4.2 With scroll function
 ![Image of the datepicker component with scroll function](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/datepicker/images/datepicker_pageable.png 'class: image')
@@ -55,7 +55,7 @@ The component has the following statuses:
 * [Disabled](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/wmQgoq#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/datepicker)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/datepicker)
 
 ### 4.3 Date range
 * Two date pickers are combined to select a date range.
@@ -75,7 +75,7 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/yaQ2xa#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/datepicker)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/datepicker)
 
 ### 4.5 Calendar layer
 ![Image of the datepicker component with visible date layer](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/datepicker/images/datepicker_picker.png 'class: image')
@@ -95,4 +95,4 @@ The tab sequence within the calender layer is defined as follows:
 * [Date range beyond a month](hhttps://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/MjM7A7#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/datepicker)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/datepicker)

--- a/documentation/components/fileselector/fileselector-de.md
+++ b/documentation/components/fileselector/fileselector-de.md
@@ -27,4 +27,4 @@ Die Komponente hat folgende Zustände:
 * [Disabled](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/WmnWbk#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/file-selector)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/file-selector)

--- a/documentation/components/fileselector/fileselector-en.md
+++ b/documentation/components/fileselector/fileselector-en.md
@@ -27,4 +27,4 @@ The component has the following statuses:
 * [Disabled](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/WmnWbk#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/file-selector)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/file-selector)

--- a/documentation/components/ghettobox/ghettobox-de.md
+++ b/documentation/components/ghettobox/ghettobox-de.md
@@ -20,7 +20,7 @@ Bei Hinweisen und Störungen welche eine ganze Applikation betreffen.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/34xd8m#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/ghettobox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/ghettobox)
 
 ### 4.2 Link
 Diese Ausprägung hat folgende Zustände:
@@ -37,4 +37,4 @@ Diese Ausprägung hat folgende Zustände:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ndDYzl#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/ghettobox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/ghettobox)

--- a/documentation/components/ghettobox/ghettobox-en.md
+++ b/documentation/components/ghettobox/ghettobox-en.md
@@ -20,7 +20,7 @@ For information and errors that concern an entire application.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/34xd8m#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/ghettobox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/ghettobox)
 
 ### 4.2 Link
 This variant has the following statuses:
@@ -37,4 +37,4 @@ This variant has the following statuses:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ndDYzl#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/ghettobox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/ghettobox)

--- a/documentation/components/lightbox/lightbox-de.md
+++ b/documentation/components/lightbox/lightbox-de.md
@@ -21,7 +21,7 @@ Dient zur Darstellung von Detailinformationen einer Content-Seite.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/QJ1g5b#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/lightbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/lightbox)
 
 ### 4.2 Mit Formularkomponenten
 ![Darstellung der Komponente Lightbox mit Formular als Inhalt](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/lightbox/images/lightbox_form.png 'class: image')
@@ -35,4 +35,4 @@ Dient zur Darstellung von Detailinformationen einer Content-Seite.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/xDQ8a0#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/lightbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/lightbox)

--- a/documentation/components/lightbox/lightbox-en.md
+++ b/documentation/components/lightbox/lightbox-en.md
@@ -21,7 +21,7 @@ It is used to display detailed information of a content page.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/QJ1g5b#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/lightbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/lightbox)
 
 ### 4.2 With form components
 ![Image of the lightbox component with form components](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/lightbox/images/lightbox_form.png 'class: image')
@@ -34,4 +34,4 @@ It is used to display detailed information of a content page.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/xDQ8a0#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/lightbox)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/lightbox)

--- a/documentation/components/link/link-de.md
+++ b/documentation/components/link/link-de.md
@@ -26,7 +26,7 @@ Die Komponente hat folgende Zustände:
 
 #### Code Spezifikation
 Der Standard-Link ist keine eigenständige Komponente sonder ist direkt im Bereich [Typografie](https://digital.sbb.ch/de/websites/basics/typography) definiert.
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ## 4.2 Lead Link 
 ![Darstellung der Komponente Link zur Anwendung in einem Lead-Text](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_lead.png 'class: image')
@@ -37,7 +37,7 @@ Der Standard-Link ist keine eigenständige Komponente sonder ist direkt im Berei
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/J9Jw5M#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)
 
 ## 4.3 Nach Textabschnitten (Paragraph)
 ![Darstellung der Komponente Link zur Anwendung nach einem Textabschnitt (Paragraph)](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_paragraph.png 'class: image')
@@ -48,7 +48,7 @@ Der Standard-Link ist keine eigenständige Komponente sonder ist direkt im Berei
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ewdA9z#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)
 
 ## 4.4 Nach Formularelementen
 ![Darstellung der Komponente Link zur Anwendung nach Formularelementen](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_form.png 'class: image')
@@ -59,7 +59,7 @@ Der Standard-Link ist keine eigenständige Komponente sonder ist direkt im Berei
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/mjKVdz#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)
 
 ## 4.5 In Menüs
 ![Darstellung der Komponente Link in Menüs](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_menu.png 'class: image')
@@ -70,7 +70,7 @@ Der Standard-Link ist keine eigenständige Komponente sonder ist direkt im Berei
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ApRlqz#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)
 
 ## 4.6 Socialmedia
 ![Darstellung der Komponente Link als Absprung zu einem Social-Media Kanal](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_icon.png 'class: image')
@@ -81,4 +81,4 @@ Der Standard-Link ist keine eigenständige Komponente sonder ist direkt im Berei
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/kPQ199#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)

--- a/documentation/components/link/link-en.md
+++ b/documentation/components/link/link-en.md
@@ -26,7 +26,7 @@ The component has the following statuses:
 
 #### Code specification
 The standard link is not an independent component but is instead defined directly in the [Typografie](https://digital.sbb.ch/en/websites/basics/typography) area.
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/typography)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/typography)
 
 ## 4.2 Lead link 
 ![Image of the link component for use in a lead text](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_lead.png 'class: image')
@@ -37,7 +37,7 @@ The standard link is not an independent component but is instead defined directl
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/J9Jw5M#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)
 
 ## 4.3 After paragraphs
 ![Image of the link component for use after a paragraph](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_paragraph.png 'class: image')
@@ -48,7 +48,7 @@ The standard link is not an independent component but is instead defined directl
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ewdA9z#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)
 
 ## 4.4 After form elements
 ![Image of the link component for use after form elements](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_form.png 'class: image')
@@ -59,7 +59,7 @@ The standard link is not an independent component but is instead defined directl
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/mjKVdz#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)
 
 ## 4.5 In menus
 ![Image of the link component in menus](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_menu.png 'class: image')
@@ -70,7 +70,7 @@ The standard link is not an independent component but is instead defined directl
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ApRlqz#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)
 
 ## 4.6 Social media
 ![Image of the link component to jump to a social media channel](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/link/images/link_icon.png 'class: image')
@@ -81,4 +81,4 @@ The standard link is not an independent component but is instead defined directl
 * [On-Click](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/kPQ199#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/links)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/links)

--- a/documentation/components/loadingindicator/loadingindicator-de.md
+++ b/documentation/components/loadingindicator/loadingindicator-de.md
@@ -23,7 +23,7 @@ Zeigt an, dass eine länger dauernde Aktion durchgeführt wird.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ozDKZx#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/loading)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/loading)
 
 ### 4.2 Small
 ![Darstellung der Komponente Ladeindikator in der Grösse klein](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/loadingindicator/images/loadingindicator_small.png 'class: image')
@@ -32,7 +32,7 @@ Zeigt an, dass eine länger dauernde Aktion durchgeführt wird.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/Rvo8Ex#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/loading)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/loading)
 
 ### 4.3 Medium 
 ![Darstellung der Komponente Ladeindikator in der Grösse mittel](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/loadingindicator/images/loadingindicator_medium.png 'class: image')
@@ -41,7 +41,7 @@ Zeigt an, dass eine länger dauernde Aktion durchgeführt wird.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/1JPWrn#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/loading)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/loading)
 
 ### 4.4 Big
 ![Darstellung der Komponente Ladeindikator in der Grösse gross](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/loadingindicator/images/loadingindicator_big.png 'class: image')
@@ -50,4 +50,4 @@ Zeigt an, dass eine länger dauernde Aktion durchgeführt wird.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/pZKwJG#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/loading)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/loading)

--- a/documentation/components/loadingindicator/loadingindicator-en.md
+++ b/documentation/components/loadingindicator/loadingindicator-en.md
@@ -22,7 +22,7 @@ It shows that a longer-lasting action is being carried out.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ozDKZx#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/loading)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/loading)
 
 ### 4.2 Small
 ![Image of the small loading indicator component](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/loadingindicator/images/loadingindicator_small.png 'class: image')
@@ -31,7 +31,7 @@ It shows that a longer-lasting action is being carried out.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/Rvo8Ex#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/loading)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/loading)
 
 ### 4.3 Medium 
 ![Image of the medium loading indicator component](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/loadingindicator/images/loadingindicator_medium.png 'class: image')
@@ -40,7 +40,7 @@ It shows that a longer-lasting action is being carried out.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/1JPWrn#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/loading)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/loading)
 
 ### 4.4 Big
 ![Image of the big loading indicator component](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/loadingindicator/images/loadingindicator_big.png 'class: image')
@@ -49,4 +49,4 @@ It shows that a longer-lasting action is being carried out.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/pZKwJG#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/loading)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/loading)

--- a/documentation/components/notification/notification-de.md
+++ b/documentation/components/notification/notification-de.md
@@ -17,7 +17,7 @@ Wenn ein Benutzer auf einer Seite eine Aktion ausgelöst hat und vom System ein 
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/rvrL4A#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/notification)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/notification)
 
 ### 4.2 Hinweis
 ![Darstellung der Komponente Notification zur Darstellung von Hinweismeldungen](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/notification/images/notification_information.png 'class: image')
@@ -26,7 +26,7 @@ Wenn ein Benutzer auf einer Seite eine Aktion ausgelöst hat und vom System ein 
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ndDYMl#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/notification)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/notification)
 
 ### 4.3 Fehler 
 ![Darstellung der Komponente Notification zur Darstellung von Fehlermeldungen](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/notification/images/notification_error.png 'class: image')
@@ -35,7 +35,7 @@ Wenn ein Benutzer auf einer Seite eine Aktion ausgelöst hat und vom System ein 
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/QJ1g7b#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/notification)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/notification)
 
 ### 4.4 Fehler mit Sprungmarke 
 ![Darstellung der Komponente Notification zur Darstellung von Fehlermeldungen mit zusätzlichen Sprungmarken](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/notification/images/notification_link.png 'class: image')
@@ -47,4 +47,4 @@ Wenn ein Benutzer auf einer Seite eine Aktion ausgelöst hat und vom System ein 
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/xDQ8E0#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/notification)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/notification)

--- a/documentation/components/notification/notification-en.md
+++ b/documentation/components/notification/notification-en.md
@@ -17,7 +17,7 @@ It is used to display messages that concern an entire page.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/rvrL4A#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/notification)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/notification)
 
 ### 4.2 Information
 ![Image of the notification component to display information messages](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/notification/images/notification_information.png 'class: image')
@@ -26,7 +26,7 @@ It is used to display messages that concern an entire page.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ndDYMl#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/notification)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/notification)
 
 ### 4.3 Error 
 ![Image of the notification component to display error messages](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/notification/images/notification_error.png 'class: image')
@@ -35,7 +35,7 @@ It is used to display messages that concern an entire page.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/QJ1g7b#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/notification)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/notification)
 
 ### 4.4 Error with jump marker 
 ![Image of the notification component to display error messages with jump marker](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/notification/images/notification_link.png 'class: image')
@@ -47,4 +47,4 @@ It is used to display messages that concern an entire page.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/xDQ8E0#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/notification)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/notification)

--- a/documentation/components/pagination/pagination-de.md
+++ b/documentation/components/pagination/pagination-de.md
@@ -29,7 +29,7 @@ Die Komponente hat folgende Zustände:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/zAKMYl#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/pagination)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/pagination)
 
 ### 4.2 Seitennamen
 Diese Ausprägung hat folgende Zustände:
@@ -46,4 +46,4 @@ Diese Ausprägung hat folgende Zustände:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/J9JwqM#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/pagination)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/pagination)

--- a/documentation/components/pagination/pagination-en.md
+++ b/documentation/components/pagination/pagination-en.md
@@ -29,7 +29,7 @@ The component has the following statuses:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/zAKMYl#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/pagination)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/pagination)
 
 ### 4.2 Page names
 This variant has the following statuses:
@@ -46,4 +46,4 @@ This variant has the following statuses:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/J9JwqM#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/pagination)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/pagination)

--- a/documentation/components/processflow/processflow-de.md
+++ b/documentation/components/processflow/processflow-de.md
@@ -17,4 +17,4 @@ Bei s√§mtlichen Prozessen bei denen ein Benutzer mehrere Schritte/Seiten durchl√
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/vOQPb1#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/processflow)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/processflow)

--- a/documentation/components/processflow/processflow-en.md
+++ b/documentation/components/processflow/processflow-en.md
@@ -17,4 +17,4 @@
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/vOQPb1#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/processflow)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/processflow)

--- a/documentation/components/radiobutton/radiobutton-de.md
+++ b/documentation/components/radiobutton/radiobutton-de.md
@@ -36,7 +36,7 @@ Die Komponente hat folgende Zustände:
 * [Disabled unchecked](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/DKwRrq#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/radio-button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button)
 
 ### 4.2 Vertikale Radiobutton-Gruppe
 ![Darstellung der Komponente Radiobutton als vertikale Gruppe](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/radiobutton/images/radiobutton_vertical.png 'class: image')
@@ -45,7 +45,7 @@ Die Komponente hat folgende Zustände:
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/j9rRy0#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/radio-button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button)
 
 ### 4.3 Horizontale Radiobutton-Gruppe
 ![Darstellung der Komponente Radiobutton als horizontale Gruppe](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/radiobutton/images/radiobutton_horizontal.png 'class: image')
@@ -54,4 +54,4 @@ Die Komponente hat folgende Zustände:
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/dKjaEZ#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/radio-button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button)

--- a/documentation/components/radiobutton/radiobutton-en.md
+++ b/documentation/components/radiobutton/radiobutton-en.md
@@ -36,7 +36,7 @@ The component has the following statuses:
 * [Disabled unchecked](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/DKwRrq#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/radio-button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button)
 
 ### 4.2 Vertical radio button group
 ![Image of the radio button component as a vertical group](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/radiobutton/images/radiobutton_vertical.png 'class: image')
@@ -45,7 +45,7 @@ The component has the following statuses:
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/j9rRy0#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/radio-button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button)
 
 ### 4.3 Horizontal radio button group
 ![Image of the radio button component as a horizontal group](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/radiobutton/images/radiobutton_horizontal.png 'class: image')
@@ -54,4 +54,4 @@ The component has the following statuses:
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/dKjaEZ#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/radio-button)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button)

--- a/documentation/components/radiobuttonpanel/radiobuttonpanel-de.md
+++ b/documentation/components/radiobuttonpanel/radiobuttonpanel-de.md
@@ -30,7 +30,7 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/4e5zrZ#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/radio-button-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button-panel)
 
 ### 4.2 Mit Infotext
 ![Darstellung der Komponente Radiobuttonpanel mit zusätzlichem Hinweistext](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/radiobuttonpanel/images/radiobuttonpanel_infotext.png 'class: image')
@@ -43,7 +43,7 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/DKwRrW#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/radio-button-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button-panel)
 
 ### 4.3 Mit Piktogramm / Logo
 ![Darstellung der Komponente Radiobuttonpanel mit zusätzlichem Piktogramm oder Logo](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/radiobuttonpanel/images/radiobuttonpanel_picto.png 'class: image')
@@ -56,4 +56,4 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/kPQ1yP#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/radio-button-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button-panel)

--- a/documentation/components/radiobuttonpanel/radiobuttonpanel-en.md
+++ b/documentation/components/radiobuttonpanel/radiobuttonpanel-en.md
@@ -30,7 +30,7 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/4e5zrZ#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/radio-button-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button-panel)
 
 ### 4.2 With info text
 ![Image of the radio button panel component with additional info text](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/radiobuttonpanel/images/radiobuttonpanel_infotext.png 'class: image')
@@ -43,7 +43,7 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/DKwRrW#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/radio-button-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button-panel)
 
 ### 4.3 With pictogram/logo
 ![Image of the radio button panel component with additional pictogram or logo](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/radiobuttonpanel/images/radiobuttonpanel_picto.png 'class: image')
@@ -56,4 +56,4 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/kPQ1yP#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/radio-button-panel)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/radio-button-panel)

--- a/documentation/components/searchfield/searchfield-de.md
+++ b/documentation/components/searchfield/searchfield-de.md
@@ -34,7 +34,7 @@ Die Komponente hat folgende Zustände:
 * [Suggested](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/1JPWRk#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/search)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/search)
 
 ### 4.2 Im Header
 Diese Ausprägung hat folgende Zustände:
@@ -59,4 +59,4 @@ Diese Ausprägung hat folgende Zustände:
 * [Suggested](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/wmQgYV#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/search)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/search)

--- a/documentation/components/searchfield/searchfield-en.md
+++ b/documentation/components/searchfield/searchfield-en.md
@@ -34,7 +34,7 @@ The component has the following statuses:
 * [Suggested](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/1JPWRk#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/search)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/search)
 
 ### 4.2 In the header
 The component has the following statuses:
@@ -59,4 +59,4 @@ The component has the following statuses:
 * [Suggested](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/wmQgYV#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/search)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/search)

--- a/documentation/components/select/select-de.md
+++ b/documentation/components/select/select-de.md
@@ -35,7 +35,7 @@ Die Komponente hat folgende Zustände:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/9aWeGP#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/select)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/select)
 
 ### 4.2 Mehrfachauswahl 
 ![Darstellung der Komponente Select mit Mehrfachauswahl](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/select/images/select_multi.png 'class: image')
@@ -45,7 +45,7 @@ Die Komponente hat folgende Zustände:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/2vejde#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/select)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/select)
 
 ### 4.3 Gruppierte Einfachauswahl
 ![Darstellung der Komponente Select mit gruppierten Einträgen](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/select/images/select_grouped_single.png 'class: image')
@@ -55,7 +55,7 @@ Die Komponente hat folgende Zustände:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/gLZlmr#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/select)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/select)
 
 ### 4.4 Gruppierte Mehrfachauswahl
 ![Darstellung der Komponente Select mit gruppierten Einträgen und Mehrfachauswahl](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/select/images/select_grouped_multi.png 'class: image')
@@ -65,4 +65,4 @@ Die Komponente hat folgende Zustände:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/5GoZJP#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/select)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/select)

--- a/documentation/components/select/select-en.md
+++ b/documentation/components/select/select-en.md
@@ -35,7 +35,7 @@ The component has the following statuses:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/9aWeGP#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/select)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/select)
 
 ### 4.2 Multiple choice 
 ![Image of the select component with multiple choice](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/select/images/select_multi.png 'class: image')
@@ -45,7 +45,7 @@ The component has the following statuses:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/gLZlmr#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/select)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/select)
 
 ### 4.3 Grouped single selection
 ![Image of the select component with grouped entries](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/select/images/select_grouped_single.png 'class: image')
@@ -55,7 +55,7 @@ The component has the following statuses:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/2vejde#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/select)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/select)
 
 ### 4.4 Grouped multiple choice
 ![Image of the select component with grouped entries and multiple choice](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/select/images/select_grouped_multi.png 'class: image')
@@ -65,4 +65,4 @@ The component has the following statuses:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/5GoZJP#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/select)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/select)

--- a/documentation/components/tab/tab-de.md
+++ b/documentation/components/tab/tab-de.md
@@ -30,7 +30,7 @@ Die Komponente hat folgende Zustände:
 * [Focused](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/rvrLVx#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/tabs)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tabs)
 
 ### 4.2 Mit Mengenindikatoren 
 ![Darstellung der Komponente Tab mit zusätzlichen Mengenindikatoren](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/tab/images/tab_indicator.png 'class: image')
@@ -44,4 +44,4 @@ Die Komponente hat folgende Zustände:
 * [Focused](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/EwG1pY#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/tabs)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tabs)

--- a/documentation/components/tab/tab-en.md
+++ b/documentation/components/tab/tab-en.md
@@ -30,7 +30,7 @@ The component has the following statuses:
 * [Focused](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/rvrLVx#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/tabs)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tabs)
 
 ### 4.2 With quantity indicator 
 ![Image of the tab component with quantity indicator](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/tab/images/tab_indicator.png 'class: image')
@@ -44,4 +44,4 @@ The component has the following statuses:
 * [Focused](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/EwG1pY#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/tabs)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tabs)

--- a/documentation/components/table/table-de.md
+++ b/documentation/components/table/table-de.md
@@ -25,7 +25,7 @@ Strukturierte Darstellung von Daten.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/j9rRA0#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/table)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/table)
 
 ### 4.2 Gruppiert
 ![Darstellung der Komponente Tabelle mit Untergruppen in den Zeilen](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/table/images/table_grouped.png 'class: image')
@@ -34,7 +34,7 @@ Strukturierte Darstellung von Daten.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/dKjaeZ#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/table)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/table)
 
 ### 4.3 Titel - Wert
 ![Darstellung der Komponente Tabelle als Titel-Wert Auflistung](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/table/images/table_key_value.png 'class: image')
@@ -43,4 +43,4 @@ Strukturierte Darstellung von Daten.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/zAKMeW#Inspector)
 
 #### ode Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/table)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/table)

--- a/documentation/components/table/table-en.md
+++ b/documentation/components/table/table-en.md
@@ -25,7 +25,7 @@ Structured display of data.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/j9rRA0#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/table)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/table)
 
 ### 4.2 Grouped
 ![Image of the table component with sub-groups in the lines](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/table/images/table_grouped.png 'class: image')
@@ -34,7 +34,7 @@ Structured display of data.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/dKjaeZ#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/table)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/table)
 
 ### 4.3 Title – value
 ![Image of the table component as a title value list](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/table/images/table_key_value.png 'class: image')
@@ -43,4 +43,4 @@ Structured display of data.
 * [Default](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/zAKMeW#Inspector)
 
 #### ode specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/table)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/table)

--- a/documentation/components/tag/tag-de.md
+++ b/documentation/components/tag/tag-de.md
@@ -35,7 +35,7 @@ Beispiel:
 * [Hover inactive](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/4e5zZZ#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/tag)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tag)
 
 ### 4.2 Linktag
 ![Darstellung der Komponente Tag zur Verwendung als Link](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/tag/images/tag_linktag.png 'class: image')
@@ -50,4 +50,4 @@ Beispiel:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/GLdVQ7#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/tag)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tag)

--- a/documentation/components/tag/tag-en.md
+++ b/documentation/components/tag/tag-en.md
@@ -35,7 +35,7 @@ Example:
 * [Hover inactive](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/4e5zZZ#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/tag)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tag)
 
 ### 4.2 Link tag
 ![Image of the filter tag component used as link](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/tag/images/tag_linktag.png 'class: image')
@@ -50,4 +50,4 @@ Example:
 * [Hover](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/GLdVQ7#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/tag)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tag)

--- a/documentation/components/textarea/textarea-de.md
+++ b/documentation/components/textarea/textarea-de.md
@@ -30,4 +30,4 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/apaOJZ#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/textarea)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/textarea)

--- a/documentation/components/textarea/textarea-en.md
+++ b/documentation/components/textarea/textarea-en.md
@@ -30,4 +30,4 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/apaOJZ#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/textarea)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/textarea)

--- a/documentation/components/textexpand/textexpand-de.md
+++ b/documentation/components/textexpand/textexpand-de.md
@@ -26,4 +26,4 @@ Die Komponente hat folgende Zustände:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/0Z7b2y#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/textexpand)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/textexpand)

--- a/documentation/components/textexpand/textexpand-en.md
+++ b/documentation/components/textexpand/textexpand-en.md
@@ -26,4 +26,4 @@ The component has the following statuses:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/0Z7b2y#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/textexpand)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/textexpand)

--- a/documentation/components/textfield/textfield-de.md
+++ b/documentation/components/textfield/textfield-de.md
@@ -37,7 +37,7 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/1JPWjk#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/field)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/field)
 
 ### 4.2 Passworteingabe
 ![Darstellung der Komponente Eingabefeld für Passwort](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/textfield/images/textfield_password.png 'class: image')
@@ -50,4 +50,4 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/KPRqQK#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/field)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/field)

--- a/documentation/components/textfield/textfield-en.md
+++ b/documentation/components/textfield/textfield-en.md
@@ -37,7 +37,7 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/1JPWjk#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/field)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/field)
 
 ### 4.2 Password entry
 ![Image of the entry field component for password entry](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/textfield/images/textfield_password.png 'class: image')
@@ -50,4 +50,4 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/KPRqQK#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/field)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/field)

--- a/documentation/components/timefield/timefield-de.md
+++ b/documentation/components/timefield/timefield-de.md
@@ -28,4 +28,4 @@ Die Komponente hat folgende Zustände:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/yaQ2p8#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/time-input)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/time-input)

--- a/documentation/components/timefield/timefield-en.md
+++ b/documentation/components/timefield/timefield-en.md
@@ -28,4 +28,4 @@ The component has the following statuses:
 * [Error](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/yaQ2p8#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/time-input)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/time-input)

--- a/documentation/components/toggle/toggle-de.md
+++ b/documentation/components/toggle/toggle-de.md
@@ -22,7 +22,7 @@ Die Komponente hat folgende Zustände:
 * [Second](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/PZoPz1#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/toggle)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/toggle)
    
 ### 4.2 Mit Icon
 ![Darstellung der Komponente Toggle-Button mit Icons](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/toggle/images/toggle_icon.png 'class: image')
@@ -32,7 +32,7 @@ Die Komponente hat folgende Zustände:
 * [Second](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/8Dp42w#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/toggle)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/toggle)
 
 ### 4.3 Mit Infotext 
 ![Darstellung der Komponente Toggle-Button mit zusätzlichen Hinweistext](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/toggle/images/toggle_infotext.png 'class: image')
@@ -42,7 +42,7 @@ Die Komponente hat folgende Zustände:
 * [Second](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/MjM72l#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/toggle)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/toggle)
 
 ### 4.4 Mit zusätzlichem Eingabekontext
 ![Darstellung der Komponente Toggle-Button mit zusätzlichem Eingabekontext](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/toggle/images/toggle_content.png 'class: image')
@@ -52,7 +52,7 @@ Die Komponente hat folgende Zustände:
 * [Second](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/bVampo#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/toggle)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/toggle)
 
 
 

--- a/documentation/components/toggle/toggle-en.md
+++ b/documentation/components/toggle/toggle-en.md
@@ -22,7 +22,7 @@ The component has the following statuses:
 * [Second](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/PZoPz1#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/toggle)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/toggle)
    
 ### 4.2 With icon
 ![Image of the toggle button component with icons](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/toggle/images/toggle_icon.png 'class: image')
@@ -32,7 +32,7 @@ The component has the following statuses:
 * [Second](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/8Dp42w#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/toggle)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/toggle)
 
 ### 4.3 With info text 
 ![Image of the toggle button component with additional information text](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/toggle/images/toggle_infotext.png 'class: image')
@@ -42,7 +42,7 @@ The component has the following statuses:
 * [Second](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/MjM72l#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/toggle)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/toggle)
 
 ### 4.4 With additional entry context
 ![Image of the toggle button component with additional entry context](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/toggle/images/toggle_content.png 'class: image')
@@ -52,7 +52,7 @@ The component has the following statuses:
 * [Second](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/bVampo#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/toggle)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/toggle)
 
 
 

--- a/documentation/components/tooltip/tooltip-de.md
+++ b/documentation/components/tooltip/tooltip-de.md
@@ -27,7 +27,7 @@ Die Komponente hat folgende Zustände:
 * [Visible](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/34xdgD#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/tooltip)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tooltip)
 
 ### 4.2 Overlay unterhalb des Icons
 ![Darstellung der Komponente Tooltip mit untenliegender Textbox](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/tooltip/images/tooltip_underneath.png 'class: image')
@@ -37,4 +37,4 @@ Die Komponente hat folgende Zustände:
 * [Visible](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ndDYOW#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/tooltip)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tooltip)

--- a/documentation/components/tooltip/tooltip-en.md
+++ b/documentation/components/tooltip/tooltip-en.md
@@ -27,7 +27,7 @@ The component has the following statuses:
 * [Visible](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/34xdgD#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/tooltip)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tooltip)
 
 ### 4.2 Overlay below the icon
 ![Image of the tooltip component with text box below it](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/tooltip/images/tooltip_underneath.png 'class: image')
@@ -37,4 +37,4 @@ The component has the following statuses:
 * [Visible](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/ndDYOW#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/tooltip)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/tooltip)

--- a/documentation/components/usermenu/usermenu-de.md
+++ b/documentation/components/usermenu/usermenu-de.md
@@ -19,7 +19,7 @@ Die Komponente hat folgende Zustände:
 ![Darstellung der Komponente Benutzermenü in der Ausprägung Standard](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/usermenu/images/usermenu_default.png 'class: image')
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/usermenu)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/usermenu)
 
 #### Design Spezifikation
 * [Logged Out](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/QJ1gZ8#Inspector)
@@ -35,7 +35,7 @@ Die Komponente hat folgende Zustände:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/zAKMVW#Inspector)
 
 #### Code Spezifikation
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/public/components/usermenu)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/usermenu)
 
 
 

--- a/documentation/components/usermenu/usermenu-en.md
+++ b/documentation/components/usermenu/usermenu-en.md
@@ -19,7 +19,7 @@ The component has the following statuses:
 ![Image of the user menu component in the standard variant](https://raw.githubusercontent.com/sbb-design-systems/design-system-website-documentation/master/documentation/components/usermenu/images/usermenu_default.png 'class: image')
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/usermenu)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/usermenu)
 
 #### Design specification
 * [Logged Out](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/QJ1gZ8#Inspector)
@@ -35,7 +35,7 @@ The component has the following statuses:
 * [Expanded](https://www.sketch.com/s/80f12b3b-58e5-4b4c-98cd-c553bae18db0/a/zAKMVW#Inspector)
 
 #### Code specification
-* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/latest/content/usermenu)
+* [SBB Angular Component Library](https://sbb-angular.app.sbb.ch/public/components/usermenu)
 
 
 


### PR DESCRIPTION
correct links to code-specification for all patterns